### PR TITLE
Camera: Allow setting fallback physical ID for logical camera [2/2]

### DIFF
--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -718,7 +718,20 @@ public final class CameraManager {
                 new HashMap<String, CameraCharacteristics>();
         Set<String> physicalCameraIds = chars.getPhysicalCameraIds();
         for (String physicalCameraId : physicalCameraIds) {
-            CameraCharacteristics physicalChars = getCameraCharacteristics(physicalCameraId);
+            CameraCharacteristics physicalChars;
+            try {
+                physicalChars = getCameraCharacteristics(physicalCameraId);
+            } catch (Exception e) {
+                final String fallbackId = SystemProperties.get(
+                        "persist.sys.camera.fallback_id_" + physicalCameraId);
+                if (fallbackId.isEmpty()) {
+                    throw e;
+                }
+                Log.w(TAG, "Could not retrieve camera " + physicalCameraId + " characteristics", e);
+                Log.i(TAG, "Trying fallback camera " + fallbackId);
+                // if this also fails, exception will be thrown
+                physicalChars = getCameraCharacteristics(fallbackId);
+            }
             physicalIdsToChars.put(physicalCameraId, physicalChars);
         }
         return physicalIdsToChars;


### PR DESCRIPTION
On Redmi Note 8 (ginkgo):

 * miui camera uses logical id 61 as depth sensor on portrait mode but oss libcam maps it to physical id 2 which is wrong, our physical id of depth sensor is 20 so we must hack it this way

Set appropriate system property, for example:
persist.sys.camera.fallback_id_2=20

Change-Id: I0c42813d8529b0d769ee8abd0307da97fbfecf5d